### PR TITLE
update podspec

### DIFF
--- a/DSFRegex.podspec
+++ b/DSFRegex.podspec
@@ -1,18 +1,15 @@
 Pod::Spec.new do |s|
-  s.name         = "DSFRegex"
-  s.version      = "2.0.0"
-  s.summary      = "A Swift based Regex class"
-  s.description  = <<-DESC
+  s.name                 = "DSFRegex"
+  s.version              = "3.1.0"
+  s.summary              = "A Swift based Regex class"
+  s.description          = <<-DESC
     A Swift regex class abstracting away the complexities of NSRegularExpression, NSRange and Swift Strings
   DESC
-  s.homepage     = "https://github.com/dagronf"
-  s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.author             = { "Darren Ford" => "dford_au-reg@yahoo.com" }
-  s.social_media_url   = ""
-  s.source       = { :git => ".git", :tag => s.version.to_s }
-  s.subspec "Core" do |ss|
-    ss.source_files  = "Sources/DSFRegex/**/*.swift"
-  end
-
-  s.swift_version = "5.0"
+  s.homepage             = "https://github.com/dagronf"
+  s.license              = { :type => "MIT", :file => "LICENSE" }
+  s.author               = { "Darren Ford" => "dford_au-reg@yahoo.com" }
+  s.source               = { :git => "https://github.com/dagronf/DSFRegex.git", :tag => s.version.to_s }
+  s.platforms            = { :ios => "12.0", :tvos => "12.0", :osx => "10.13", :watchos => "4.0" }
+  s.source_files         = 'Sources/DSFRegex/**/*.swift'
+  s.swift_versions       = ['5.3', '5.4', '5.5', '5.6', '5.7']
 end


### PR DESCRIPTION
Updating podspec file to publish **DSFRegex** on Cocoapods dependency manager.
This process will release the module on the Cocoapods public spec repo.

This will release the latest version of **DSFRegex** which is 3.1.0

This module is used as a dependency in the module [**SwiftSubtitles**](https://github.com/dagronf/SwiftSubtitles).
This module needs to be made available in order for **SwiftSubtitles** to pass validation.

Validation checked and passing.
Validating with command: `pod spec lint DSFRegex.podspec --verbose` at the root of the project directory.